### PR TITLE
Translated one more Chinese term to Model.

### DIFF
--- a/src/pages/sport/sport/template/dashboardStr.js
+++ b/src/pages/sport/sport/template/dashboardStr.js
@@ -41,7 +41,7 @@ function dashboardStr(data) {
 								<p><span>${data.step}</span>Steps</p>
 							</div>
 							<div class = 'model'>
-								<p>型号:${data.name}<p>
+								<p>Model:${data.name}<p>
 							</div>
 						</div>
 						<div class='position-info' hidden>


### PR DESCRIPTION
Translated 型号 to "Model" for src/pages/sport/sport/template/dashboardStr.js

These are the Chinese words/terms that I looked for:
1:   开始
2：运动数据实时监测系统
3：配置
4：型号 (fixed in template dashboardStr.js file)
5：蓝牙路由器配置
6：终端配置
7：控制方式
8：本地
9：云端
10：测试
11：移除

1-11 (except 4) are located in src/public-resource/config/lang.json
If cn selected, Chinese shows up. Needs en to be selected for English.