### PR TITLE
Temporarily changed all Chinese translations in lang.json to English …

### DIFF
--- a/src/public-resource/config/lang.json
+++ b/src/public-resource/config/lang.json
@@ -1,19 +1,19 @@
 {
     "sport": {
         "cn": {
-            "lang": "cn",
-            "title": "运动数据实时监测系统",
-            "startWork": "开始",
-            "config": "配置",
-            "control":"控制方式",
-            "local":"本地",
-            "remote":"云端",
-            "test":"测试",
-            "deletes":"移除",
-            "Nolocation":"否",
-            "Yeslocation":"是",
-            "btRouterConfig":"蓝牙路由器配置",
-            "wristbandConfig":"终端配置"
+            "lang": "en",
+            "title": "Sport Real-time Monitoring System",
+            "startWork": "Start",
+            "config": "Config",
+            "control":"control",
+            "local":"local",
+            "remote":"remote",
+            "test":"Test",
+            "deletes":"Delete",
+            "Nolocation":"NO",
+            "Yeslocation":"YES",
+            "btRouterConfig":"Bluetooth Router Configuration",
+            "wristbandConfig":"Wristband Configuration"
 
         },
         "en": {


### PR DESCRIPTION
…for a customer demo. In future versions, the intent will be to move all globalization translations into lang.json, using navigator.language to select default local language text.